### PR TITLE
Upgrade deprecated runtime nodejs4.3

### DIFF
--- a/cloudformation/classiclinkmirror_lambda_template.json
+++ b/cloudformation/classiclinkmirror_lambda_template.json
@@ -30,7 +30,7 @@
                 "Description": "This event-triggered Lambda function monitors user-tagged EC2-Classic Security Groups, maintaining mirror Security Groups in the specified VPCs and ClassicLinking member EC2 instances to them",
                 "Handler": "index.handler",
                 "Role": { "Fn::GetAtt": [ "LambdaExecRole", "Arn" ] },
-                "Runtime": "nodejs4.3",
+                "Runtime": "nodejs10.x",
                 "Timeout": "60"
             }
         },


### PR DESCRIPTION
CloudFormation templates in ec2-classic-mirror have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs4.3). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.